### PR TITLE
FIX additional exception handling for Tika errors return via Guzzle.

### DIFF
--- a/code/extractors/SolrCellTextExtractor.php
+++ b/code/extractors/SolrCellTextExtractor.php
@@ -72,7 +72,19 @@ class SolrCellTextExtractor extends FileTextExtractor {
 				SS_Log::NOTICE
 			);
 			return null;
+		} catch(Guzzle\Http\Exception\ServerErrorResponseException $e){
+			//catch other errors that Tika can throw vai Guzzle but are not caught and break Solr search query in some cases.
+			SS_Log::log(
+				sprintf(
+					'Tika server error attempting to extract from "%s" (message: %s)', 
+					$path, 
+					$e->getMessage()
+				),
+				SS_Log::NOTICE
+			);
+			return null;
 		}
+
 		// Use preg match to avoid SimpleXML running out of memory on large text nodes
 		preg_match(
 			sprintf('/\<str name\="%s"\>(.*?)\<\/str\>/s', preg_quote($fileName)),


### PR DESCRIPTION
Tika server errors via Guzzle can cause the Solr search query to return a 500 error and breaks search results pages for users. Issue was relating to uncaught exceptions from Guzzle causing a silent fail if a text file is perhaps unreadable or missing (return null never occurs which breaks the search). 

Please check patch over and test on other server OS's, this fixed a major error when running this module on SLE11 SP2.
