### PR TITLE
FIX UnexpectedValueException thrown when trying to set SolrCellTextEx…

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,7 +4,7 @@ Name: textextraction
 Injector:
   FileTextCache: FileTextCache_Database
 
-SolrCellTextExtractor:
+#SolrCellTextExtractor:
 #  base_url: 'http://localhost:8983/solr/update/extract'
 
 FileTextCache_Database:


### PR DESCRIPTION
…traction.base_url in config

Defining this config setting in yml like this causes an error when you try to set it again because the config parser thinks that there is a type mis-match