### PR TITLE
FIX PDFTextExtractor no longer smushes words together than break acro…

### DIFF
--- a/code/extractors/PDFTextExtractor.php
+++ b/code/extractors/PDFTextExtractor.php
@@ -110,10 +110,10 @@ class PDFTextExtractor extends FileTextExtractor
             throw new FileTextExtractor_Exception(sprintf(
                 'PDFTextExtractor->getContent() failed for %s: %s',
                 $path,
-                implode('', $err)
+                implode(PHP_EOL, $err)
             ));
         }
-        return implode('', $content);
+        return implode(PHP_EOL, $content);
     }
 
     /**


### PR DESCRIPTION
…ss lines

This `implode` was causing an issue where words that were separated by new lines in a PDF would be smushed together into one word.