### PR TITLE
fixed the version comparison for tika server text extractor

### DIFF
--- a/code/extractors/TikaServerTextExtractor.php
+++ b/code/extractors/TikaServerTextExtractor.php
@@ -72,7 +72,7 @@ class TikaServerTextExtractor extends FileTextExtractor
     {
         return $this->getServerEndpoint() &&
             $this->getClient()->isAvailable() &&
-            $this->getVersion() >= 1.7;
+            version_compare($this->getVersion(), '1.7.0') >= 0;
     }
 
     public function supportsExtension($extension)


### PR DESCRIPTION
fixed the version comparison using version_compare() instead of plain float