### PR TITLE
Don't try to save the object to the cache if it has been disabled

### DIFF
--- a/code/extensions/FileTextExtractable.php
+++ b/code/extensions/FileTextExtractable.php
@@ -83,7 +83,9 @@ class FileTextExtractable extends DataExtension
             return null;
         }
 
-        $this->getTextCache()->save($this->owner, $text);
+        if (!$disableCache) {
+                $this->getTextCache()->save($this->owner, $text);
+        }
 
         return $text;
     }


### PR DESCRIPTION
If you disable the cache in a call to `extractFileAsText`; the extracted text is still added to the cache.