### PR TITLE
Ensure that the version number has a major, minor and patch number

### DIFF
--- a/code/extractors/TikaServerTextExtractor.php
+++ b/code/extractors/TikaServerTextExtractor.php
@@ -120,7 +120,7 @@ class TikaServerTextExtractor extends FileTextExtractor
      * Ensure that the version number has a major, minor and patch number
      * Reason being that version_compare('1.7', '1.7.0') will return -1 instead of 0
      *
-     * @param $version
+     * @param float $version
      * @return string
      */
     protected function normaliseVersion($version)

--- a/code/extractors/TikaServerTextExtractor.php
+++ b/code/extractors/TikaServerTextExtractor.php
@@ -71,13 +71,7 @@ class TikaServerTextExtractor extends FileTextExtractor
     public function isAvailable()
     {
         $version = $this->getVersion();
-        // ensure that the version number has a major, minor and patch number
-        // reason being that version_compare('1.7', '1.7.0') will return -1 instead of 0
-        for ($i = 0; $i < 2; $i++) {
-            if (substr_count($version, '.') < 2) {
-                $version .= '.0';
-            }
-        }
+        $version = $this->normaliseVersion($version);
         return $this->getServerEndpoint() &&
             $this->getClient()->isAvailable() &&
             version_compare($version, '1.7.0') >= 0;
@@ -120,5 +114,25 @@ class TikaServerTextExtractor extends FileTextExtractor
     public function getContent($path)
     {
         return $this->getClient()->tika($path);
+    }
+
+    /**
+     * Ensure that the version number has a major, minor and patch number
+     * Reason being that version_compare('1.7', '1.7.0') will return -1 instead of 0
+     *
+     * @param $version
+     * @return string
+     */
+    protected function normaliseVersion($version)
+    {
+        if (!$version) {
+            return '0.0.0';
+        }
+        for ($i = 0; $i < 2; $i++) {
+            if (substr_count($version, '.') < 2) {
+                $version .= '.0';
+            }
+        }
+        return $version;
     }
 }

--- a/code/extractors/TikaServerTextExtractor.php
+++ b/code/extractors/TikaServerTextExtractor.php
@@ -70,9 +70,17 @@ class TikaServerTextExtractor extends FileTextExtractor
 
     public function isAvailable()
     {
+        $version = $this->getVersion();
+        // ensure that the version number has a major, minor and patch number
+        // reason being that version_compare('1.7', '1.7.0') will return -1 instead of 0
+        for ($i = 0; $i < 2; $i++) {
+            if (substr_count($version, '.') < 2) {
+                $version .= '.0';
+            }
+        }
         return $this->getServerEndpoint() &&
             $this->getClient()->isAvailable() &&
-            version_compare($this->getVersion(), '1.7.0') >= 0;
+            version_compare($version, '1.7.0') >= 0;
     }
 
     public function supportsExtension($extension)

--- a/tests/TikaTextExtractorTest.php
+++ b/tests/TikaTextExtractorTest.php
@@ -40,4 +40,24 @@ class TikaTextExtractorTest extends SapphireTest
         $this->assertTrue($extractor->supportsMime('text/html'));
         $this->assertFalse($extractor->supportsMime('application/not-supported'));
     }
+    public function testNormaliseVersion()
+    {
+        $extractor = new TikaServerTextExtractor();
+        $reflection = new ReflectionClass($extractor);
+        $method = $reflection->getMethod('normaliseVersion');
+        $method->setAccessible(true);
+
+        $arr = [
+            '1.7.1' => '1.7.1',
+            '1.7' => '1.7.0',
+            '1' => '1.0.0',
+            null => '0.0.0',
+            'v1.5' => 'v1.5.0',
+            'carrot' => 'carrot.0.0'
+        ];
+        foreach ($arr as $input => $expected) {
+            $actual = $method->invoke($extractor, $input);
+            $this->assertEquals($expected, $actual);
+        }
+    }
 }

--- a/tests/TikaTextExtractorTest.php
+++ b/tests/TikaTextExtractorTest.php
@@ -40,6 +40,7 @@ class TikaTextExtractorTest extends SapphireTest
         $this->assertTrue($extractor->supportsMime('text/html'));
         $this->assertFalse($extractor->supportsMime('application/not-supported'));
     }
+    
     public function testNormaliseVersion()
     {
         $extractor = new TikaServerTextExtractor();

--- a/tests/TikaTextExtractorTest.php
+++ b/tests/TikaTextExtractorTest.php
@@ -48,17 +48,22 @@ class TikaTextExtractorTest extends SapphireTest
         $method = $reflection->getMethod('normaliseVersion');
         $method->setAccessible(true);
 
-        $arr = [
-            '1.7.1' => '1.7.1',
-            '1.7' => '1.7.0',
-            '1' => '1.0.0',
-            null => '0.0.0',
-            'v1.5' => 'v1.5.0',
-            'carrot' => 'carrot.0.0'
-        ];
-        foreach ($arr as $input => $expected) {
+        foreach ($this->versionProvider() as $data) {
+            list($input, $expected) = $data;
             $actual = $method->invoke($extractor, $input);
             $this->assertEquals($expected, $actual);
         }
+    }
+    
+    protected function versionProvider()
+    {
+        return [
+            ['1.7.1', '1.7.1'],
+            ['1.7', '1.7.0'],
+            ['1', '1.0.0'],
+            [null, '0.0.0'],
+            ['v1.5', 'v1.5.0'],
+            ['carrot', 'carrot.0.0']
+        ];
     }
 }

--- a/tests/TikaTextExtractorTest.php
+++ b/tests/TikaTextExtractorTest.php
@@ -57,13 +57,13 @@ class TikaTextExtractorTest extends SapphireTest
     
     protected function versionProvider()
     {
-        return [
-            ['1.7.1', '1.7.1'],
-            ['1.7', '1.7.0'],
-            ['1', '1.0.0'],
-            [null, '0.0.0'],
-            ['v1.5', 'v1.5.0'],
-            ['carrot', 'carrot.0.0']
-        ];
+        return array(
+            array('1.7.1', '1.7.1'),
+            array('1.7', '1.7.0'),
+            array('1', '1.0.0'),
+            array(null, '0.0.0'),
+            array('v1.5', 'v1.5.0'),
+            array('carrot', 'carrot.0.0')
+        );
     }
 }


### PR DESCRIPTION
This fixes an issue with running the textextraction module on circle ci installs that have tika 1.7