### PR TITLE
Update isAvailable check to work for identical versions

### DIFF
--- a/src/Extractor/TikaServerTextExtractor.php
+++ b/src/Extractor/TikaServerTextExtractor.php
@@ -86,7 +86,7 @@ class TikaServerTextExtractor extends FileTextExtractor
     {
         return $this->getServerEndpoint()
             && $this->getClient()->isAvailable()
-            && version_compare($this->getVersion(), '1.7.0') >= 0;
+            && version_compare($this->getVersion(), '1.7') >= 0;
     }
 
     /**

--- a/tests/TikaServerTextExtractorTest.php
+++ b/tests/TikaServerTextExtractorTest.php
@@ -2,9 +2,11 @@
 
 namespace SilverStripe\TextExtraction\Tests;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Assets\File;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\TextExtraction\Extractor\TikaServerTextExtractor;
+use SilverStripe\TextExtraction\Rest\TikaRestClient;
 
 /**
  * @group tika-tests
@@ -32,5 +34,45 @@ class TikaServerTextExtractorTest extends SapphireTest
         $this->assertTrue($extractor->supportsMime('application/pdf'));
         $this->assertTrue($extractor->supportsMime('text/html'));
         $this->assertFalse($extractor->supportsMime('application/not-supported'));
+    }
+
+    /**
+     * @param string $version
+     * @param bool $expected
+     * @dataProvider isAvailableProvider
+     */
+    public function testIsAvailable($version, $expected)
+    {
+        /** @var PHPUnit_Framework_MockObject_MockObject|TikaServerTextExtractor $extractor */
+        $extractor = $this->getMockBuilder(TikaServerTextExtractor::class)
+            ->setMethods(['getClient', 'getServerEndpoint'])
+            ->getMock();
+
+        $client = $this->createMock(TikaRestClient::class);
+        $client->method('isAvailable')->willReturn(true);
+        $client->method('getVersion')->willReturn($version);
+
+        $extractor->method('getClient')->willReturn($client);
+        $extractor->method('getServerEndpoint')->willReturn('tikaserver.example');
+
+        $result = $extractor->isAvailable();
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function isAvailableProvider()
+    {
+        return [
+            ['1.5.2', false],
+            ['1.5', false],
+            ['1.7.0', true],
+            ['1.7.5', true],
+            ['1.8.0', true],
+            ['1.7', true],
+            ['1.8', true],
+            ['2.0.0', true],
+        ];
     }
 }


### PR DESCRIPTION
Tika server reports it's version as "Apache Tika 1.7". Unfortunately, `version_compare` in PHP says that version "1.7" is less than version "1.7.0", meaning that Tika server was incorrectly being ruled out unless you used Tika server version 1.8 (where "1.8" > "1.7.0").

Changing the comparison string to just "1.7" means they match exactly, and therefore `version_compare` will return `0` rather than `-1`.