### PR TITLE
FIX Ensure Tika responses are casted as strings, fixes broken unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - php: 7.1
       env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
+    - php: 7.3
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
@@ -34,7 +36,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-core "$RECIPE_VERSION"
+  - composer require --no-update silverstripe/recipe-cms:"$RECIPE_VERSION"
   - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql 2.1.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,12 @@
         "squizlabs/php_codesniffer": "^3",
         "phpunit/phpunit": "^5.7"
     },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\TextExtraction\\": "src/",
+            "SilverStripe\\TextExtraction\\Tests\\": "tests/"
+        }
+    },
     "suggest": {
         "ext-fileinfo": "Improved support for file mime detection"
     },

--- a/src/Rest/TikaRestClient.php
+++ b/src/Rest/TikaRestClient.php
@@ -149,7 +149,7 @@ class TikaRestClient extends Client
             Injector::inst()->get(LoggerInterface::class)->info($msg);
         }
 
-        return $text;
+        return (string) $text;
     }
 
     /**


### PR DESCRIPTION
They can be returned as a stream, but the TikaRestClient response is documented as a string

Fixes the broken builds and adds missing PSR-4 autoloader definitions to composer.json