### PR TITLE
Return version number as string instead of float

### DIFF
--- a/src/Rest/TikaRestClient.php
+++ b/src/Rest/TikaRestClient.php
@@ -70,22 +70,22 @@ class TikaRestClient extends Client
     /**
      * Get version code
      *
-     * @return float
+     * @return string
      */
     public function getVersion()
     {
         /** @var Response $response */
         $response = $this->get('version', $this->getGuzzleOptions());
-        $version = 0.0;
+        $version = 0;
 
         // Parse output
         if ($response->getStatusCode() == 200
             && preg_match('/Apache Tika (?<version>[\.\d]+)/', $response->getBody(), $matches)
         ) {
-            $version = (float)$matches['version'];
+            $version = $matches['version'];
         }
 
-        return $version;
+        return (string) $version;
     }
 
     /**


### PR DESCRIPTION
SilverStripe 4.3
Tika Server 1.20

Ran into a small version comparison issue in `TikaRestClient.php`. If you are using Tika Server 1.20 (and assuming for future versions 1.30, 1.40 etc). The version number is being cast to a float so "1.20" becomes 1.2 and fails the `version_compare()` call in `TikaServerTextExtractor.php`.

Not sure if Apache Tika is using semantic versioning, but if that is the case, then the comparator from https://github.com/composer/semver might be a better option that `version_compare()`.