### PR TITLE
#54 Cleanup temporary file

### DIFF
--- a/src/Extractor/TikaServerTextExtractor.php
+++ b/src/Extractor/TikaServerTextExtractor.php
@@ -127,6 +127,11 @@ class TikaServerTextExtractor extends FileTextExtractor
     public function getContent($file)
     {
         $tempFile = $file instanceof File ? $this->getPathFromFile($file) : $file;
-        return $this->getClient()->tika($tempFile);
+        $content = $this->getClient()->tika($tempFile);
+        //Cleanup temp file
+        if ($tempFile instanceof File) {
+            unlink($tempFile);
+        }
+        return $content;
     }
 }

--- a/src/Extractor/TikaServerTextExtractor.php
+++ b/src/Extractor/TikaServerTextExtractor.php
@@ -129,7 +129,7 @@ class TikaServerTextExtractor extends FileTextExtractor
         $tempFile = $file instanceof File ? $this->getPathFromFile($file) : $file;
         $content = $this->getClient()->tika($tempFile);
         //Cleanup temp file
-        if ($tempFile instanceof File) {
+        if ($file instanceof File) {
             unlink($tempFile);
         }
         return $content;

--- a/src/Extractor/TikaTextExtractor.php
+++ b/src/Extractor/TikaTextExtractor.php
@@ -81,7 +81,7 @@ class TikaTextExtractor extends FileTextExtractor
         $command = sprintf('tika %s %s', $mode, escapeshellarg($path));
         $code = $this->runShell($command, $output);
         //Cleanup temp file
-        if ($path instanceof File) {
+        if ($file instanceof File) {
             unlink($path);
         }
 

--- a/src/Extractor/TikaTextExtractor.php
+++ b/src/Extractor/TikaTextExtractor.php
@@ -80,6 +80,10 @@ class TikaTextExtractor extends FileTextExtractor
         $path = $file instanceof File ? $this->getPathFromFile($file) : $file;
         $command = sprintf('tika %s %s', $mode, escapeshellarg($path));
         $code = $this->runShell($command, $output);
+        //Cleanup temp file
+        if ($path instanceof File) {
+            unlink($path);
+        }
 
         if ($code == 0) {
             return $output;


### PR DESCRIPTION
This cleans the created temporary file after extracting content in TikaServerTextExtractor and TikaTextExtractor.
It is a fix to avoid that issue from happening without changing the signatures or the way the content is extracted from files and used in the TikaRestClient, hence it's fully backwards compatible.

Resolves #54