### PR TITLE
Update for 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=3.x-dev
+    - COMPOSER_ROOT_VERSION=3.1.x-dev
     - SS_TIKA_ENDPOINT="http://localhost:9998/"
 
 matrix:


### PR DESCRIPTION
composer.json does not need to be updated
```
    "require": {
        "silverstripe/framework": "^4",
        "silverstripe/assets": "^1",
        "silverstripe/versioned": "^1",
        "guzzlehttp/guzzle": "~6.3.0"
    },
```