### PR TITLE
DEP Loosen constraints for guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/assets": "^1",
         "silverstripe/versioned": "^1",
-        "guzzlehttp/guzzle": "~6.3.0"
+        "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",


### PR DESCRIPTION
Fixes #66

I've checked the the [6.0 to 7.0 upgrade guide](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70) and there don't seem to be any compatibility issues with 7.x, and it seems like the original restriction that prohibited >= 6.4.0 was unintentionally stricter than necessary.