### PR TITLE
DOCS Fix incorrect PHPDoc about what null lifetime means.

### DIFF
--- a/src/Cache/FileTextCache/Cache.php
+++ b/src/Cache/FileTextCache/Cache.php
@@ -18,7 +18,7 @@ class Cache implements FileTextCache, Flushable
 
     /**
      * Lifetime of cache in seconds
-     * Null is indefinite
+     * Null defaults to 3600 (1 hour)
      *
      * @var int|null
      * @config


### PR DESCRIPTION
Fixes #70 