### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/assets": "1.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
+        "silverstripe/framework": "^4.10",
+        "silverstripe/assets": "^1",
+        "silverstripe/versioned": "^1",
         "guzzlehttp/guzzle": "^6.3 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33