### PR TITLE
MNT Remove unit test metadata

### DIFF
--- a/tests/TikaServerTextExtractorTest.php
+++ b/tests/TikaServerTextExtractorTest.php
@@ -9,9 +9,6 @@ use SilverStripe\TextExtraction\Extractor\TikaServerTextExtractor;
 use SilverStripe\TextExtraction\Rest\TikaRestClient;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @group tika-tests
- */
 class TikaServerTextExtractorTest extends SapphireTest
 {
     protected $usesDatabase = true;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/331

Not related to php84 though doing at same time, removes this notice

Metadata found in doc-comment for class SilverStripe\TextExtraction\Tests\TikaServerTextExtractorTest. Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.